### PR TITLE
Fixed Cygwin building and Modifed README.md

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "3rd/c-ares"]
 	path = 3rd/c-ares
 	url = https://github.com/zhc105/c-ares.git
+	branch = dev
 	ignore = dirty
 [submodule "3rd/libev"]
 	path = 3rd/libev

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ include(ExternalProject)
 # Build submodule json-parser
 ExternalProject_Add(
     json-parser 
-    SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/3rd/json-parser
+    SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/3rd/json-parser
     PREFIX ${CMAKE_CURRENT_BINARY_DIR}/build/json-parser
     BUILD_IN_SOURCE true
     CONFIGURE_COMMAND sh <SOURCE_DIR>/configure
@@ -36,7 +36,7 @@ set_target_properties(libjsonparser PROPERTIES
 # Build submodule ev
 ExternalProject_Add(ev
     BUILD_IN_SOURCE true
-    SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/3rd/libev
+    SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/3rd/libev
     PREFIX ${CMAKE_CURRENT_BINARY_DIR}/build/libev
     CONFIGURE_COMMAND sh <SOURCE_DIR>/autogen.sh COMMAND sh <SOURCE_DIR>/configure
     BUILD_COMMAND ${MAKE}
@@ -61,7 +61,7 @@ set_target_properties(libev PROPERTIES
 # Build c-ares
 ExternalProject_Add(c-ares
     BUILD_IN_SOURCE true
-    SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/3rd/c-ares
+    SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/3rd/c-ares
     INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/3rd/c-ares/output
     PREFIX ${CMAKE_CURRENT_BINARY_DIR}/build/c-ares
     CMAKE_ARGS -DCARES_SHARED=off -DCARES_STATIC=on -DCARES_BUILD_TOOLS=off -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/3rd/c-ares/output

--- a/README.md
+++ b/README.md
@@ -14,18 +14,26 @@ Liteflow实现了一套简易的可靠UDP传输协议(LiteDT)，并基于这个�
 ### 编译和使用手册
 
 ```
-#编译
+# Clone
+git clone --recurse-submodules https://github.com/zhc105/Liteflow.git
+或者
+git clone --recurse-submodules git@github.com:zhc105/Liteflow.git
+
+# 编译
+cmake .
 make
 
-#检查版本
+目前只支持在源码目录编译，不支持使用另一个目录存放编译生成文件，例如`mkdir out && cd out && cmake .. && make`。
+
+# 检查版本
 ./liteflow --version
 
-#部署配置文件，与程序在同一目录下，文件名为{二进制程序名}.conf。如程序名为liteflow，则配置文件名为liteflow.conf
+# 部署配置文件，与程序在同一目录下，文件名为{二进制程序名}.conf。如程序名为liteflow，则配置文件名为liteflow.conf
 
-#运行
+# 运行
 ./liteflow
 
-#重新加载配置(仅支持listen_list和allow_list)
+# 重新加载配置(仅支持listen_list和allow_list)
 kill -SIGUSR1 $(liteflow_pid)
 ```
 
@@ -136,3 +144,18 @@ kill -SIGUSR1 $(liteflow_pid)
 }
 
 ```
+
+### Cygwin编译Windows版本
+Liteflow支持通过Cygwin编译提供Windows可用版本。
+
+Cygwin必须至少安装以下Packages：
+* git
+* gcc-core
+* gcc-g++
+* make
+* automake
+* cmake
+* autoconf
+* libtool
+
+其它编译步骤与正常流程相同。编译完成后，将`cygwin1.dll`和产生的`liteflow.exe`复制到需要运行Liteflow的Windows机器上，准备好相应的配置文件并直接运行`liteflow.exe`。


### PR DESCRIPTION
1. Fixed Cygwin building by using a fixed branch dev in c-ares.
2. Modifed README.md to include Cygwin building steps.
3. Fixed some CMakeLists.txt issue. But for now we still don't support running cmake in other folder.