### PR TITLE
Add option to test config file, use argp_parse and clean logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,14 @@ cmake ..
 make
 cd src
 
+# 帮助文档
+./liteflow --help
+
 # 检查版本
 ./liteflow --version
+
+# 测试配置文件是否合法
+./liteflow -t -c ./liteflow.conf
 
 # 部署配置文件
 

--- a/src/config.h
+++ b/src/config.h
@@ -103,7 +103,7 @@ typedef struct _global_config {
 } global_config_t;
 
 void global_config_init();
-void load_config_file(const char *filename);
+int load_config_file(const char *filename);
 int  reload_config_file();
 
 #ifndef _CONFIG_C_

--- a/src/ctrl.c
+++ b/src/ctrl.c
@@ -181,7 +181,7 @@ static void update_pacing_rate(ctrl_mod_t *ctrl)
         host->snd_cwnd = cwnd * bbr_probe_rtt_gain >> BBR_SCALE;
         break;
     default:
-        LOG("Fatal: ctrl bad mode: %u\n", ctrl->bbr_mode);
+        LOG("Fatal: ctrl bad mode: %u", ctrl->bbr_mode);
         assert(0);
         break;
     }
@@ -221,7 +221,7 @@ static void update_min_rtt(ctrl_mod_t *ctrl, const rate_sample_t *rs)
         ctrl->prior_bw = bw;
         ctrl->probe_rtt_cwnd_target = cwnd * bbr_probe_rtt_gain >> BBR_SCALE;
         ctrl->probe_rtt_done_stamp = 0;
-        DBG("enter probe_rtt mode, min_rtt=%u\n", ctrl->min_rtt_us);
+        DBG("enter probe_rtt mode, min_rtt=%u", ctrl->min_rtt_us);
     }
 
     if (ctrl->bbr_mode == BBR_PROBE_RTT) {
@@ -278,7 +278,7 @@ static void check_probe_rtt_done(ctrl_mod_t *ctrl)
     host->pacing_rate += get_pacing_rate_fec(ctrl, host->pacing_rate);
     host->snd_cwnd = cwnd * bbr_cwnd_gain >> BBR_SCALE;
     ctrl->bbr_mode = BBR_PROBE_BW;
-    DBG("leave probe_rtt mode, min_rtt=%u\n", ctrl->min_rtt_us);
+    DBG("leave probe_rtt mode, min_rtt=%u", ctrl->min_rtt_us);
     pacing_rate_postcheck(ctrl);
 }
 
@@ -290,7 +290,7 @@ static void check_drain(ctrl_mod_t *ctrl)
     if (ctrl->bbr_mode == BBR_STARTUP && ctrl->full_bw_reached) {
         ctrl->bbr_mode = BBR_DRAIN;
         ctrl->full_bdp = get_bdp(ctrl, ctrl->full_bw);
-        DBG("enter drain mode, bdp=%u\n", ctrl->full_bdp);
+        DBG("enter drain mode, bdp=%u", ctrl->full_bdp);
     }
 
     if (ctrl->bbr_mode == BBR_DRAIN) {
@@ -303,7 +303,7 @@ static void check_drain(ctrl_mod_t *ctrl)
             host->pacing_rate = ctrl->full_bw * g_config.transport.mtu;
             host->pacing_rate += get_pacing_rate_fec(ctrl, host->pacing_rate);
             host->snd_cwnd = cwnd * bbr_cwnd_gain >> BBR_SCALE;
-            DBG("enter probe_bw mode, inflight=%u\n", host->inflight);
+            DBG("enter probe_bw mode, inflight=%u", host->inflight);
         }
     }
 }

--- a/src/fec.c
+++ b/src/fec.c
@@ -173,7 +173,7 @@ int fec_insert(
         (fidx < FEC_MEMBERS_MAX && fidx >= fmems) || !buf_len)
         return 0;
     if (buf_len > LITEDT_MTU_MAX) {
-        LOG("Warning, FEC data size exceed. flow: %u, pack_len=%zu.\n",
+        LOG("Warning, FEC data size exceed. flow: %u, pack_len=%zu.",
             fecmod->flow, buf_len);
         return 0;
     }
@@ -242,12 +242,12 @@ int fec_insert(
                 fec->fec_end = dp->seq + dp->len;    // update fec_end
             fecmod->fec_recv_start = fec->fec_end;
 
-            //DBG("recover success seq=%u\n", dp->seq);
+            //DBG("recover success seq=%u", dp->seq);
             litedt_on_data_recv(fecmod->host, fecmod->flow, dp, 1);
             ++fecmod->host->stat.fec_recover;
             // Caution: pointer fec might be invalid now
         } else {
-            LOG("Warning, FEC data recover failed flow: %u.\n", fecmod->flow);
+            LOG("Warning, FEC data recover failed flow: %u.", fecmod->flow);
         }
     }
 

--- a/src/litedt.c
+++ b/src/litedt.c
@@ -153,7 +153,7 @@ int create_connection(
 
     ret = timerlist_push(&host->conn_queue, cur_time, &flow, &conn_buf);
     if (ret != 0) {
-        DBG("create connection %u failed: %d\n", flow, ret);
+        DBG("create connection %u failed: %d", flow, ret);
         return ret;
     }
     conn = (litedt_conn_t*)timerlist_get(&host->conn_queue, NULL, &flow);
@@ -190,14 +190,14 @@ int create_connection(
         conn->fec_enabled = 1;
         ret = fec_mod_init(&conn->fec, host, flow);
         if (ret != 0) {
-            LOG("error: FEC init failed: %d\n", ret);
+            LOG("error: FEC init failed: %d", ret);
             retrans_mod_fini(&conn->retrans);
             timerlist_del(&host->conn_queue, &flow);
             return ret;
         }
     }
 
-    DBG("create connection %u success\n", flow);
+    DBG("create connection %u success", flow);
     litedt_mod_evtime(host, conn, cur_time);
 
     return ret;
@@ -229,7 +229,7 @@ void release_connection(litedt_host_t *host, uint32_t flow)
     time_wait.close_time = get_curtime();
     queue_append(&host->timewait_queue, &flow, &time_wait);
 
-    DBG("connection %u released\n", flow);
+    DBG("connection %u released", flow);
 }
 
 void release_all_connections(litedt_host_t *host)
@@ -427,7 +427,7 @@ int litedt_data_post(litedt_host_t *host, uint32_t flow, uint32_t seq,
             &conn->retrans, seq, len, fec_seq, fec_index);
         if (ret && ret != LITEDT_RECORD_EXISTS) {
             LOG("ERROR: failed to create packet entry: "
-                "seq=%u, len=%u, ret=%d\n", seq, len, ret);
+                "seq=%u, len=%u, ret=%d", seq, len, ret);
         }
     }
 
@@ -441,7 +441,7 @@ int litedt_data_post(litedt_host_t *host, uint32_t flow, uint32_t seq,
     }
 
     if (send_ret == LITEDT_SEND_FLOW_CONTROL)  {
-        DBG("Warning: unexpected flow control during sending data!\n");
+        DBG("Warning: unexpected flow control during sending data!");
         return LITEDT_SEND_FLOW_CONTROL;
     }
 
@@ -483,7 +483,7 @@ int litedt_data_ack(litedt_host_t *host, uint32_t flow, int ack_list)
                 break;
         }
         ack->ack_size = cnt;
-        //DBG("ack_size:%u remain:%u\n", cnt, treemap_size(&conn->sack_map));
+        //DBG("ack_size:%u remain:%u", cnt, treemap_size(&conn->sack_map));
     } else {
         ack->ack_size = 0;
     }
@@ -506,7 +506,7 @@ int litedt_close_req(litedt_host_t *host, uint32_t flow, uint32_t last_seq)
     build_litedt_header(header, LITEDT_CLOSE_REQ, flow);
 
     req->last_seq = last_seq;
-    DBG("send close req: %u\n", last_seq);
+    DBG("send close req: %u", last_seq);
 
     plen = sizeof(litedt_header_t) + sizeof(close_req_t);
     socket_send(host, buf, plen, 1);
@@ -802,7 +802,7 @@ int litedt_on_ping_rsp(litedt_host_t *host, ping_rsp_t *rsp)
     host->ping_rtt = (uint32_t)ping_rtt;
     host->next_ping_time = host->cur_time + PING_INTERVAL;
     host->offline_time = get_offline_time(host->cur_time);
-    DBG("ping rsp, rtt=%u\n", host->ping_rtt);
+    DBG("ping rsp, rtt=%u", host->ping_rtt);
 
     if (!host->remote_online) {
         uint16_t node = rsp->node_id;
@@ -852,7 +852,7 @@ int litedt_on_conn_rsp(litedt_host_t *host, uint32_t flow, conn_rsp_t *rsp)
     if (0 == rsp->status) {
         if (conn->state == CONN_REQUEST) {
             conn->state = CONN_ESTABLISHED;
-            DBG("connection %u established\n", flow);
+            DBG("connection %u established", flow);
         }
 
         // send ack when connection established
@@ -987,7 +987,7 @@ int litedt_on_close_req(litedt_host_t *host, uint32_t flow, close_req_t *req)
         litedt_close_rsp(host, flow);
         return 0;
     }
-    DBG("recv close req: end_seq=%u\n", req->last_seq);
+    DBG("recv close req: end_seq=%u", req->last_seq);
 
     if (conn->state == CONN_FIN_WAIT) {
         release_connection(host, flow);
@@ -1032,7 +1032,7 @@ int litedt_on_conn_rst(litedt_host_t *host, uint32_t flow)
         litedt_mod_evtime(host, conn, host->cur_time);
     }
 
-    DBG("connection %u reset\n", flow);
+    DBG("connection %u reset", flow);
     return 0;
 }
 
@@ -1176,7 +1176,7 @@ void litedt_io_event(litedt_host_t *host, char *buf, size_t recv_len)
         // connection error or closed already, send rst to client
         if (ret != LITEDT_RECORD_NOT_FOUND ||
             queue_get(&host->timewait_queue, &flow) == NULL) {
-            LOG("Connection %u error, reset\n", flow);
+            LOG("Connection %u error, reset", flow);
         }
         litedt_conn_rst(host, flow);
     }
@@ -1217,7 +1217,6 @@ litedt_time_t litedt_time_event(litedt_host_t *host)
 
     if (cur_time >= host->offline_time) {
         uint16_t node = host->peer_node_id;
-
         host->offline_time = get_offline_time(cur_time);
         release_all_connections(host);
         host->remote_online = 0;
@@ -1655,7 +1654,7 @@ static int is_snd_queue_empty(litedt_conn_t *conn)
 static int check_peer_node_id(litedt_host_t *host, uint16_t node_id)
 {
     if (host->peer_node_id && host->peer_node_id != node_id) {
-        LOG("Warning: Peer id mismatch, expect: %u, actual: %u\n",
+        LOG("Warning: Peer id mismatch, expect: %u, actual: %u",
             host->peer_node_id, node_id);
 
         return 1;

--- a/src/liteflow.c
+++ b/src/liteflow.c
@@ -287,20 +287,20 @@ parse_peer_address_port(peer_info_t *peer, const char *address_port)
     peer->port = DEFAULT_PORT;
 
     if (address_port_len > DOMAIN_PORT_MAX_LEN - 1) {
-        LOG("Warning: peer address length exceed\n");
+        LOG("Warning: peer address length exceed");
         return;
     }
 
     if ((pos = strrchr(address_port, ':')) != NULL) {
         if (pos - address_port >= DOMAIN_MAX_LEN) {
-            LOG("Warning: peer address length exceed\n");
+            LOG("Warning: peer address length exceed");
             return;
         }
         strncpy(peer->address, address_port, pos - address_port);
         peer->port = atoi(pos + 1);
     } else {
         if (address_port_len >= DOMAIN_MAX_LEN) {
-            LOG("Warning: peer address length exceed\n");
+            LOG("Warning: peer address length exceed");
             return;
         }
         strncpy(peer->address, address_port, DOMAIN_MAX_LEN);
@@ -344,7 +344,7 @@ try_accept_peer(litedt_header_t *header, char *buf, size_t len,
         ++peers_inbound_cnt;
         peer = new_peer_inbound(peer_id, addr, addr_len);
         if (peer == NULL) {
-            LOG("Failed to create inbound peer\n");
+            LOG("Failed to create inbound peer");
             return;
         }
     }
@@ -425,14 +425,14 @@ new_peer_inbound(uint16_t peer_id, const struct sockaddr *peer_addr,
 
     peer = new_peer();
     if (peer == NULL) {
-        LOG("Failed to create inbound peer\n");
+        LOG("Failed to create inbound peer");
         return NULL;
     }
 
     peer->is_outbound = 0;
     peer->peer_id = peer_id;
     if ((ret = queue_append(&peers_tab, &peer_id, &peer)) != 0) {
-        LOG("Failed to create liteflow peer: %d\n", ret);
+        LOG("Failed to create liteflow peer: %d", ret);
         return NULL;
     }
 
@@ -449,13 +449,13 @@ new_peer_outbound(const char *address_port)
 
     strncpy(addr_buf, address_port, DOMAIN_PORT_MAX_LEN - 1);
     if (queue_get(&peers_outbound, addr_buf)) {
-        LOG("Duplicated peer: %s\n", address_port);
+        LOG("Duplicated peer: %s", address_port);
         return NULL;
     }
 
     peer = new_peer();
     if (peer == NULL) {
-        LOG("Failed to create outbound peer\n");
+        LOG("Failed to create outbound peer");
         return NULL;
     }
 
@@ -463,7 +463,7 @@ new_peer_outbound(const char *address_port)
     peer->resolve_ipv6 = g_config.service.prefer_ipv6 ? 1 : 0;
     parse_peer_address_port(peer, address_port);
     if ((ret = queue_append(&peers_outbound, addr_buf, &peer)) != 0) {
-        LOG("Failed to insert outbound peer: %d\n", ret);
+        LOG("Failed to insert outbound peer: %d", ret);
         return NULL;
     }
 
@@ -589,10 +589,10 @@ peer_start(peer_info_t *peer, const struct sockaddr *peer_addr,
 
     // remove old address from addrs_tab
     if (peer->bound_addr_key.family != AF_UNSPEC) {
-        LOG("Reassign peer[%u] address to [%s]:%u\n", peer->peer_id, ip, port);
+        LOG("Reassign peer[%u] address to [%s]:%u", peer->peer_id, ip, port);
         queue_del(&addrs_tab, &peer->bound_addr_key);
     } else {
-        LOG("Adding new peer[%u] with address [%s]:%u\n", peer->peer_id, ip,
+        LOG("Adding new peer[%u] with address [%s]:%u", peer->peer_id, ip,
             port);
     }
 
@@ -621,7 +621,7 @@ liteflow_on_online(litedt_host_t *host, int online)
     litedt_time_t cur_time = get_curtime();
 
     if (online) {
-        LOG("%s peer[%u] is online\n",
+        LOG("%s peer[%u] is online",
             peer->is_outbound ? "Outbound" : "Inbound",
             host->peer_node_id);
 
@@ -631,7 +631,7 @@ liteflow_on_online(litedt_host_t *host, int online)
             if (ptr != NULL && *ptr != peer) {
                 peer_info_t *old_peer = *ptr;
                 // Outbound peer may conflict with an inbound peer
-                LOG("Warning: Overwrite conflict peer[%u] from [%s]:%u\n",
+                LOG("Warning: Overwrite conflict peer[%u] from [%s]:%u",
                     peer->peer_id, peer->address, peer->port);
                 if (ev_is_active(&old_peer->time_watcher))
                     ev_timer_stop(loop, &old_peer->time_watcher);
@@ -647,7 +647,7 @@ liteflow_on_online(litedt_host_t *host, int online)
             queue_append(&peers_tab, &peer->peer_id, &peer);
         }
     } else {
-        LOG("%s peer[%u] is offline\n",
+        LOG("%s peer[%u] is offline",
             peer->is_outbound ? "Outbound" : "Inbound",
             host->peer_node_id);
 
@@ -665,12 +665,12 @@ liteflow_on_online(litedt_host_t *host, int online)
                 && queue_empty(&peers_tab)) {
                 // if listen_port not specified and no active peers, will try to
                 // reset socket to listen on a new random port
-                LOG("Reset socket to listen on a new random port.\n");
+                LOG("Reset socket to listen on a new random port.");
                 reset_litedt_sock();
                 last_sock_reset_time = cur_time;
             }
 
-            LOG("Notice: Reconnecting [%s]:%u.\n", peer->address, peer->port);
+            LOG("Notice: Reconnecting [%s]:%u.", peer->address, peer->port);
             resolve_outbound_peer(peer);
         } else {
             release_peer(peer);
@@ -684,7 +684,7 @@ liteflow_on_connect(litedt_host_t *host, uint32_t flow, uint16_t tunnel_id)
     int idx = 0, ret;
     peer_info_t *peer = (peer_info_t*)litedt_ext(host);
 
-    DBG("request connect: tunnel_id=%u\n", tunnel_id);
+    DBG("request connect: tunnel_id=%u", tunnel_id);
     while (g_config.forward_rules[idx].destination_port) {
         forward_rule_t *forward = &g_config.forward_rules[idx++];
         if (forward->tunnel_id != tunnel_id)
@@ -757,7 +757,7 @@ ares_state_cb(void *data, int s, int read, int write)
         ev_io_set(&dns_io_watcher, -1, 0);
     }
 
-    DBG("ares_state_cb: fd:%d read:%d write:%d\n", s, read, write);
+    DBG("ares_state_cb: fd:%d read:%d write:%d", s, read, write);
 }
 
 static void
@@ -769,7 +769,7 @@ dns_query_cb(void *arg, int status, int timeouts, struct hostent *host)
 
     if(!host || status != ARES_SUCCESS || !host->h_addr_list
             || !host->h_addr_list[0]){
-        LOG("Domain resolve failed (%s).\n", ares_strerror(status));
+        LOG("Domain resolve failed (%s).", ares_strerror(status));
 
         /* Sleep 10 seconds then retry resolve domain */
         if (ev_is_active(&peer->time_watcher))
@@ -779,7 +779,7 @@ dns_query_cb(void *arg, int status, int timeouts, struct hostent *host)
         ev_timer_start(loop, &peer->time_watcher);
     } else {
         inet_ntop(host->h_addrtype, host->h_addr_list[0], ip, ADDRESS_MAX_LEN);
-        LOG("Domain resolve success %s => %s\n", peer->address, ip);
+        LOG("Domain resolve success %s => %s", peer->address, ip);
 
         if (host->h_addrtype == AF_INET) {
             struct sockaddr_in *addr = (struct sockaddr_in *)&storage;
@@ -865,13 +865,13 @@ monitor_cb(struct ev_loop *loop, struct ev_timer *w, int revents)
 
         if (need_reload_conf) {
             need_reload_conf = 0;
-            LOG("Starting reload configuration.\n");
+            LOG("Starting reload configuration.");
             if ((ret = reload_config_file()) == 0) {
                 tcp_local_reload(loop, g_config.entrance_rules);
                 udp_local_reload(loop, g_config.entrance_rules);
-                LOG("Reload configuration success.\n");
+                LOG("Reload configuration success.");
             } else {
-                LOG("Reload configuration failed: %d\n", ret);
+                LOG("Reload configuration failed: %d", ret);
             }
         }
     }
@@ -898,13 +898,13 @@ print_statistics()
     queue_node_t *it = queue_first(&peers_tab);
 
     LOG("|%-7s|%-10s|%-10s|%-10s|%-10s|%-10s|%-10s|%-10s|%-10s|%-10s|%-10s"
-        "|%-10s|%-10s|%-10s|\n",
+        "|%-10s|%-10s|%-10s|",
         "NodeID", "In Bytes", "Out Bytes", "Sent Pkts", "Retrans", "Inflight",
         "FEC Recov", "Dup Pkts", "Connects", "TimeWaits", "RTT(ms)", "Cwnd",
         "Bandwidth", "State");
 
     if (queue_empty(&peers_tab)) {
-        LOG("| - No Active Peers -\n");
+        LOG("| - No Active Peers -");
     }
 
     uint32_t app_limited = 0, rate_limited = 0, cwnd_limited = 0;
@@ -915,7 +915,7 @@ print_statistics()
         stat = litedt_get_stat(&peer->dt);
 
         LOG("|%-7u|%-10u|%-10u|%-10u|%-10u|%-10u|%-10u|%-10u|%-10u|"
-            "%-10u|%-10u|%-10u|%-10s|%-10s|\n",
+            "%-10u|%-10u|%-10u|%-10s|%-10s|",
             peer->peer_id,
             stat->recv_bytes_stat,
             stat->send_bytes_stat,
@@ -1019,7 +1019,7 @@ static int init_resolver()
 
     ret = ares_library_init(ARES_LIB_INIT_ALL);
     if (ret != ARES_SUCCESS) {
-        LOG("ares_library_init: %s\n", ares_strerror(ret));
+        LOG("ares_library_init: %s", ares_strerror(ret));
         return -4;
     }
 
@@ -1028,7 +1028,7 @@ static int init_resolver()
 
     ret = ares_init_options(&g_channel, &options, optmask);
     if(ret != ARES_SUCCESS) {
-        LOG("ares_init_options: %s\n", ares_strerror(ret));
+        LOG("ares_init_options: %s", ares_strerror(ret));
         return -4;
     }
 
@@ -1037,7 +1037,7 @@ static int init_resolver()
             g_channel,
             g_config.service.dns_server);
         if (ret != ARES_SUCCESS) {
-            LOG("failed to set nameservers\n");
+            LOG("failed to set nameservers");
             return -4;
         }
     }
@@ -1063,7 +1063,7 @@ static int init_litedt_sock()
     } else {
         af = get_addr_family(listen_addr);
         if (af < 0 || (af != AF_INET && af != AF_INET6)) {
-            LOG("Error: unknown listen_addr format\n");
+            LOG("Error: unknown listen_addr format");
             return LITEDT_PARAMETER_ERROR;
         }
     }
@@ -1178,17 +1178,17 @@ int init_liteflow()
             break;
     }
     if (ret != 0) {
-        LOG("Local port init failed\n");
+        LOG("Local port init failed");
         return ret;
     }
 
     for (idx = 0; g_config.service.connect_peers[idx][0]; idx++) {
-        LOG("Adding new peer: %s\n", g_config.service.connect_peers[idx]);
+        LOG("Adding new peer: %s", g_config.service.connect_peers[idx]);
         new_peer_outbound(g_config.service.connect_peers[idx]);
     }
 
     if ((ret = init_litedt_sock()) != 0) {
-        LOG("litedt_host startup failed: %d\n", ret);
+        LOG("litedt_host startup failed: %d", ret);
         return -1;
     }
 

--- a/src/main.c
+++ b/src/main.c
@@ -26,37 +26,94 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <stdbool.h>
 #include <signal.h>
+#include <argp.h>
+
 #include "config.h"
 #include "util.h"
 #include "liteflow.h"
 #include "version.h"
 
+#define VERSION_MAX_SIZE 256
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif // PATH_MAX
+
+static char program_version[VERSION_MAX_SIZE];
+const char *argp_program_version = NULL;
+const char *argp_program_bug_address = "<me@zhc105.net>";
+const char doc[] = "UDP tunnel & TCP/UDP Port forwarding";
+static struct argp_option options[] = {
+    {"config", 'c', "CONFIG_FILE", 0,
+        "Specify the config file path. If not specified, the default value is <exe_name>.conf.", 0},
+    {"test-config", 't', NULL, 0,
+        "Test the config file and exit.", 0},
+    {0}
+};
+
+static char config_name[PATH_MAX] = { 0 };
+static bool test_mode = false;
+
+static error_t parse_opt(int key, char *arg, struct argp_state *state) {
+    int ret;
+    (void)state;
+    switch (key) {
+        case 'c':
+            strncpy(config_name, arg, sizeof(config_name) - 1);
+            break;
+        case 't':
+            test_mode = true;
+            break;
+        case ARGP_KEY_ARG:
+            LOG("Invalid parameter %s.", arg);
+        default:
+            return ARGP_ERR_UNKNOWN;
+    }
+    return 0;
+}
+
+static struct argp argp = { options, parse_opt, NULL, doc };
+
 int main(int argc, char *argv[])
 {
     int ret = 0;
-    static char config_name[256] = { 0 };
 
-    if (argc > 1 && !strcmp(argv[1], "--version")) {
-        printf("Liteflow %s\nby Moonflow <me@zhc105.net>\n", liteflow_version);
-        return 0;
-    }
+    // The config file path is set to <exe_name>.conf by default.
+    snprintf(config_name, sizeof(config_name), "%s.conf", argv[0]);
+    snprintf(program_version, sizeof(program_version), "%s", liteflow_version);
+    argp_program_version = program_version;
+
+    global_config_init();
+
+    argp_parse(&argp, argc, argv, 0, 0, NULL);
 
     srand(time(NULL));
     signal(SIGPIPE, SIG_IGN);
 
-    if (argc >= 3 && !strcmp(argv[1], "-c")) {
-        strncpy(config_name, argv[2], sizeof(config_name) - 1);
-    } else {
-        snprintf(config_name, sizeof(config_name), "%s.conf", argv[0]);
+    if(test_mode) {
+        LOG("Validating liteflow config file %s.", config_name);
     }
 
-    global_config_init();
-    load_config_file(config_name);
+    ret = load_config_file(config_name);
+
+    if(test_mode) {
+        if (NO_ERROR == ret) {
+            LOG("Config file %s is valid.", config_name);
+        } else {
+            LOG("Config file %s has mistake and please check the error message.",
+                config_name);
+        }
+
+        return ret;
+    } else if (NO_ERROR != ret) {
+        LOG("liteflow config file %s loading failed!", config_name);
+        return ret;
+    }
 
     ret = init_liteflow();
     if (ret != 0) {
-        LOG("liteflow init failed!\n");
+        LOG("liteflow init failed!");
         return ret;
     }
 

--- a/src/retrans.c
+++ b/src/retrans.c
@@ -367,7 +367,7 @@ static void queue_retrans(retrans_mod_t *rtmod, packet_entry_t *packet,
     if (packet->retrans_round < 65535)
         ++packet->retrans_round;
     if (packet->retrans_round >= 10) {
-        DBG("flow: %u, seq: %u, retrans %d times.\n",
+        DBG("flow: %u, seq: %u, retrans %d times.",
             rtmod->conn->flow, packet->seq, packet->retrans_round);
     }
 

--- a/src/tcp.c
+++ b/src/tcp.c
@@ -83,7 +83,7 @@ int tcp_local_init(struct ev_loop *loop, entrance_rule_t *entrance)
 
     af = get_addr_family(entrance->listen_addr);
     if (af < 0 || (af != AF_INET && af != AF_INET6)) {
-        LOG("Error: Failed to init tcp entrance, bad listen_addr: %s\n",
+        LOG("Error: Failed to init tcp entrance, bad listen_addr: %s",
             entrance->listen_addr);
         return -1;
     }
@@ -142,7 +142,7 @@ int tcp_local_init(struct ev_loop *loop, entrance_rule_t *entrance)
 
     host = (hsock_data_t *)malloc(sizeof(hsock_data_t));
     if (NULL == host) {
-        LOG("Warning: malloc failed\n");
+        LOG("Warning: malloc failed");
         close(sockfd);
         return -4;
     }
@@ -175,7 +175,7 @@ int tcp_local_reload(struct ev_loop *loop, entrance_rule_t *entrances)
             if (!strcmp(hsock_list[i]->local_addr, entry->listen_addr)
                 && hsock_list[i]->local_port == entry->listen_port) {
                 if (hsock_list[i]->tunnel_id != entry->tunnel_id) {
-                    LOG("[TCP]Update port [%s]:%u tunnel_id %u => %u\n",
+                    LOG("[TCP]Update port [%s]:%u tunnel_id %u => %u",
                         hsock_list[i]->local_addr,
                         hsock_list[i]->local_port,
                         hsock_list[i]->tunnel_id,
@@ -189,7 +189,7 @@ int tcp_local_reload(struct ev_loop *loop, entrance_rule_t *entrances)
         }
 
         if (!exist) {
-            LOG("[TCP]Release [%s]:%u tunnel_id %u\n",
+            LOG("[TCP]Release [%s]:%u tunnel_id %u",
                 hsock_list[i]->local_addr,
                 hsock_list[i]->local_port,
                 hsock_list[i]->tunnel_id);
@@ -228,7 +228,7 @@ int tcp_local_reload(struct ev_loop *loop, entrance_rule_t *entrances)
         }
 
         if (!exist) {
-            LOG("[TCP]Bind new tunnel[%u] on [%s]:%u\n",
+            LOG("[TCP]Bind new tunnel[%u] on [%s]:%u",
                 entry->tunnel_id,
                 entry->listen_addr,
                 entry->listen_port);
@@ -252,7 +252,7 @@ void tcp_local_recv(struct ev_loop *loop, struct ev_io *watcher, int revents)
         writable = litedt_writable_bytes(&tcp_ext->peer->dt, tcp_ext->flow);
         if (writable <= 0) {
             DBG("flow %u sendbuf is full, waiting for liteflow become "
-                "writable.\n", tcp_ext->flow);
+                "writable.", tcp_ext->flow);
             litedt_set_notify_send(&tcp_ext->peer->dt, tcp_ext->flow, 1);
             ev_io_stop(loop, watcher);
             break;
@@ -288,7 +288,7 @@ void tcp_local_send(struct ev_loop *loop, struct ev_io *watcher, int revents)
         readable = litedt_readable_bytes(&tcp_ext->peer->dt, tcp_ext->flow);
         if (readable <= 0) {
             DBG("flow %u recvbuf is empty, waiting for udp side receive "
-                "more data.\n", tcp_ext->flow);
+                "more data.", tcp_ext->flow);
             litedt_set_notify_recv(&tcp_ext->peer->dt, tcp_ext->flow, 1);
             ev_io_stop(loop, watcher);
             break;
@@ -315,18 +315,18 @@ void host_accept_cb(struct ev_loop *loop, struct ev_io *watcher, int revents)
     if (EV_READ & revents) {
         sockfd = accept(watcher->fd, (struct sockaddr *)&storage, &addr_len);
         if (sockfd < 0) {
-            LOG("Warning: tcp accept faild\n");
+            LOG("Warning: tcp accept faild");
             return;
         }
         if (fcntl(sockfd, F_SETFL, fcntl(sockfd, F_GETFL) | O_NONBLOCK) < 0 ||
                 fcntl(sockfd, F_SETFD, FD_CLOEXEC) < 0) {
-            LOG("Warning: set socket nonblock faild\n");
+            LOG("Warning: set socket nonblock faild");
             close(sockfd);
             return;
         }
 
         if ((peer = find_peer(hsock->peer_forward)) == NULL) {
-            LOG("Failed to forward connection: peer[%u] offline\n",
+            LOG("Failed to forward connection: peer[%u] offline",
                 hsock->peer_forward);
             close(sockfd);
             return;
@@ -334,7 +334,7 @@ void host_accept_cb(struct ev_loop *loop, struct ev_io *watcher, int revents)
 
         tcp_flow_t *tcp_ext = (tcp_flow_t *)malloc(sizeof(tcp_flow_t));
         if (NULL == tcp_ext) {
-            LOG("Warning: malloc failed\n");
+            LOG("Warning: malloc failed");
             close(sockfd);
             return;
         }
@@ -376,7 +376,7 @@ int tcp_remote_init(peer_info_t *peer, uint32_t flow, char *ip, int port)
 
     af = get_addr_family(ip);
     if (af < 0 || (af != AF_INET && af != AF_INET6)) {
-        LOG("Error: Failed to connect remote addr, bad address: %s\n", ip);
+        LOG("Error: Failed to connect remote addr, bad address: %s", ip);
         ret = LITEFLOW_PARAMETER_ERROR;
         goto errout;
     }
@@ -394,14 +394,14 @@ int tcp_remote_init(peer_info_t *peer, uint32_t flow, char *ip, int port)
 
     if (fcntl(sockfd, F_SETFL, fcntl(sockfd, F_GETFL) | O_NONBLOCK) < 0 ||
             fcntl(sockfd, F_SETFD, FD_CLOEXEC) < 0) {
-        LOG("Warning: set socket nonblock faild\n");
+        LOG("Warning: set socket nonblock faild");
         ret = LITEFLOW_INTERNAL_ERROR;
         goto errout;
     }
 
     tcp_ext = (tcp_flow_t *)malloc(sizeof(tcp_flow_t));
     if (NULL == tcp_ext) {
-        LOG("Warning: malloc failed\n");
+        LOG("Warning: malloc failed");
         ret = LITEFLOW_MEM_ALLOC_ERROR;
         goto errout;
     }
@@ -475,7 +475,7 @@ void tcp_remote_recv(litedt_host_t *host, flow_info_t *flow, int readable)
         if (ret < read_len) {
             // partial send success, waiting for socket become writable
             DBG("flow %u tcp sendbuf is full, waiting for socket become "
-                "writable.\n", flow->flow);
+                "writable.", flow->flow);
             ev_io_start(g_loop, &tcp_ext->w_write);
             litedt_set_notify_recv(host, flow->flow, 0);
             break;
@@ -500,7 +500,7 @@ void tcp_remote_send(litedt_host_t *host, flow_info_t *flow, int writable)
                     || errno == EINTR)) {
             // no data to recv, waiting for socket become readable
             DBG("flow %u tcp recvbuf is empty, waiting for tcp side receive "
-                "more data.\n", flow->flow);
+                "more data.", flow->flow);
             ev_io_start(g_loop, &tcp_ext->w_read);
             litedt_set_notify_send(host, flow->flow, 0);
             break;

--- a/src/udp.c
+++ b/src/udp.c
@@ -121,14 +121,14 @@ int create_udp_bind(struct sockaddr *addr, socklen_t addr_len, int host_fd,
     udp_flow_t *udp_ext = NULL;
 
     if ((peer = find_peer(peer_forward)) == NULL) {
-        LOG("Failed to forward connection: peer[%u] offline\n",
+        LOG("Failed to forward connection: peer[%u] offline",
                 peer_forward);
         return -1;
     }
 
     udp_ext = (udp_flow_t *)malloc(sizeof(udp_flow_t));
     if (NULL == udp_ext) {
-        LOG("Warning: malloc failed\n");
+        LOG("Warning: malloc failed");
         return -1;
     }
 
@@ -196,13 +196,13 @@ int udp_local_init(struct ev_loop *loop, entrance_rule_t *entrance)
     hsock_data_t *host;
 
     if (hsock_cnt >= MAX_PORT_NUM) {
-        LOG("Error: udp listen ports maximum number exceed\n");
+        LOG("Error: udp listen ports maximum number exceed");
         return -1;
     }
 
     af = get_addr_family(entrance->listen_addr);
     if (af < 0 || (af != AF_INET && af != AF_INET6)) {
-        LOG("Error: Failed to init udp entrance, bad listen_addr: %s\n",
+        LOG("Error: Failed to init udp entrance, bad listen_addr: %s",
             entrance->listen_addr);
         return -1;
     }
@@ -248,7 +248,7 @@ int udp_local_init(struct ev_loop *loop, entrance_rule_t *entrance)
 
     host = (hsock_data_t *)malloc(sizeof(hsock_data_t));
     if (NULL == host) {
-        LOG("Warning: malloc failed\n");
+        LOG("Warning: malloc failed");
         close(sockfd);
         return -4;
     }
@@ -281,7 +281,7 @@ int udp_local_reload(struct ev_loop *loop, entrance_rule_t *entrances)
             if (!strcmp(hsock_list[i]->local_addr, entry->listen_addr)
                 && hsock_list[i]->local_port == entry->listen_port) {
                 if (hsock_list[i]->tunnel_id != entry->tunnel_id) {
-                    LOG("[UDP]Update port [%s]:%u tunnel_id %u => %u\n",
+                    LOG("[UDP]Update port [%s]:%u tunnel_id %u => %u",
                         hsock_list[i]->local_addr,
                         hsock_list[i]->local_port,
                         hsock_list[i]->tunnel_id,
@@ -295,7 +295,7 @@ int udp_local_reload(struct ev_loop *loop, entrance_rule_t *entrances)
         }
 
         if (!exist) {
-            LOG("[UDP]Release [%s]:%u tunnel_id %u\n",
+            LOG("[UDP]Release [%s]:%u tunnel_id %u",
                 hsock_list[i]->local_addr,
                 hsock_list[i]->local_port,
                 hsock_list[i]->tunnel_id);
@@ -334,7 +334,7 @@ int udp_local_reload(struct ev_loop *loop, entrance_rule_t *entrances)
         }
 
         if (!exist) {
-            LOG("[UDP]Bind new tunnel[%u] on [%s]:%u\n",
+            LOG("[UDP]Bind new tunnel[%u] on [%s]:%u",
                 entry->tunnel_id,
                 entry->listen_addr,
                 entry->listen_port);
@@ -382,13 +382,13 @@ void udp_host_recv(struct ev_loop *loop, struct ev_io *watcher, int revents)
         flow = ubind->flow;
         writable = litedt_writable_bytes(&ubind->peer->dt, flow);
         if (read_len + 2 > writable) {
-            DBG("LiteDT Buffer is full, udp packet lost.\n");
+            DBG("LiteDT Buffer is full, udp packet lost.");
             litedt_stat_t *stat = litedt_get_stat(&ubind->peer->dt);
             ++stat->udp_lost;
             continue;
         }
         if (read_len > 0xFFFF) {
-            LOG("Error: udp packet too large\n");
+            LOG("Error: udp packet too large");
             continue;
         }
         // forward udp packet
@@ -413,7 +413,7 @@ void udp_local_recv(struct ev_loop *loop, struct ev_io *watcher, int revents)
 
         writable = litedt_writable_bytes(&udp_ext->peer->dt, udp_ext->flow);
         if (read_len + 2 > writable) {
-            DBG("LiteDT Buffer is full, udp packet lost.\n");
+            DBG("LiteDT Buffer is full, udp packet lost.");
             litedt_stat_t *stat = litedt_get_stat(&udp_ext->peer->dt);
             ++stat->udp_lost;
             continue;
@@ -433,7 +433,7 @@ int udp_remote_init(peer_info_t *peer, uint32_t flow, char *ip, int port)
 
     af = get_addr_family(ip);
     if (af < 0 || (af != AF_INET && af != AF_INET6)) {
-        LOG("Error: Failed to connect remote addr, bad address: %s\n", ip);
+        LOG("Error: Failed to connect remote addr, bad address: %s", ip);
         ret = LITEFLOW_PARAMETER_ERROR;
         goto errout;
     }
@@ -446,14 +446,14 @@ int udp_remote_init(peer_info_t *peer, uint32_t flow, char *ip, int port)
 
     if (fcntl(sockfd, F_SETFL, fcntl(sockfd, F_GETFL) | O_NONBLOCK) < 0 ||
             fcntl(sockfd, F_SETFD, FD_CLOEXEC) < 0) {
-        LOG("Warning: set socket nonblock faild\n");
+        LOG("Warning: set socket nonblock faild");
         ret = LITEFLOW_INTERNAL_ERROR;
         goto errout;
     }
 
     udp_ext = (udp_flow_t *)malloc(sizeof(udp_flow_t));
     if (NULL == udp_ext) {
-        LOG("Warning: malloc failed\n");
+        LOG("Warning: malloc failed");
         ret = LITEFLOW_MEM_ALLOC_ERROR;
         goto errout;
     }
@@ -565,7 +565,7 @@ void udp_remote_close(litedt_host_t *host, flow_info_t *flow)
         queue_del(&udp_tab, &ukey);
         get_ip_port((const struct sockaddr*)&udp_ext->sock_addr, ip,
             ADDRESS_MAX_LEN, &port);
-        DBG("udp connection flow:%u, from [%s]:%u was expired.\n",
+        DBG("udp connection flow:%u, from [%s]:%u was expired.",
             flow->flow, ip, port);
     }
 
@@ -582,7 +582,7 @@ static void convert_to_udp_key(int host_fd, struct sockaddr *addr,
     case AF_INET:
         {
             if (addr_len < sizeof(struct sockaddr_in)) {
-                LOG("Warning: addr_len small than expected %u\n", addr_len);
+                LOG("Warning: addr_len small than expected %u", addr_len);
                 break;
             }
 
@@ -595,7 +595,7 @@ static void convert_to_udp_key(int host_fd, struct sockaddr *addr,
     case AF_INET6:
         {
             if (addr_len < sizeof(struct sockaddr_in6)) {
-                LOG("Warning: addr_len small than expected %u\n", addr_len);
+                LOG("Warning: addr_len small than expected %u", addr_len);
                 break;
             }
 
@@ -605,7 +605,7 @@ static void convert_to_udp_key(int host_fd, struct sockaddr *addr,
             break;
         }
     default:
-        LOG("Warning: unknown sa_family %u\n", addr->sa_family);
+        LOG("Warning: unknown sa_family %u", addr->sa_family);
         break;
     }
 }

--- a/src/util.h
+++ b/src/util.h
@@ -45,7 +45,7 @@
         char timestr[20]; \
         time_t now = time(NULL); \
         strftime(timestr, 20, "%Y-%m-%d %H:%M:%S", localtime(&now)); \
-        fprintf(stdout, "[%s] " fmt, timestr, ## __VA_ARGS__); \
+        fprintf(stdout, "[%s] " fmt "\n", timestr, ## __VA_ARGS__); \
         fflush(stdout); \
     } while (0)
 
@@ -54,7 +54,7 @@
         char timestr[20]; \
         time_t now = time(NULL); \
         strftime(timestr, 20, "%Y-%m-%d %H:%M:%S", localtime(&now)); \
-        fprintf(stdout, "[%s] " fmt, timestr, ## __VA_ARGS__); \
+        fprintf(stdout, "[%s] " fmt "\n", timestr, ## __VA_ARGS__); \
         fflush(stdout); \
     } while (0)
 


### PR DESCRIPTION
Add option to test config file, use argp_parse and clean logs.

1. Add -t command to test a config file.
2. Use argp_parse function to parse arguments.
3. Remove tail /n from all LOG and DBG calls.